### PR TITLE
fix: augment `@nuxt/schema` rather than `nuxt/schema`

### DIFF
--- a/packages/vue-query-nuxt/src/nuxt-types.d.ts
+++ b/packages/vue-query-nuxt/src/nuxt-types.d.ts
@@ -6,10 +6,4 @@ declare module "@nuxt/schema" {
   }
 }
 
-declare module "nuxt/schema" {
-  interface PublicRuntimeConfig {
-    vueQuery: VueQueryOptions
-  }
-}
-
 export {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context: https://github.com/nuxt/nuxt/issues/28332

`nuxt/schema` is a re-export of `@nuxt/schema` for users to use. Modules should not augment it, or it may end up overwriting the inferred types from `@nuxt/schema`.

(We made the change in https://github.com/nuxt/module-builder/pull/295 (released in v0.8.0 of `@nuxt/module-builder`) to avoid doing this in `@nuxt/module-builder` itself.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
