### PR TITLE
fix: use `srcDir` instead of `rootDir`

### DIFF
--- a/packages/vue-query-nuxt/src/module.ts
+++ b/packages/vue-query-nuxt/src/module.ts
@@ -38,8 +38,8 @@ export default defineNuxtModule<ModuleOptions>({
       filename,
       write: true,
       getContents: async () => {
-        if (existsSync(resolve(nuxt.options.rootDir, "vue-query.config.ts"))) {
-          const configFile = resolve(nuxt.options.rootDir, "vue-query.config.ts")
+        if (existsSync(resolve(nuxt.options.srcDir, "vue-query.config.ts"))) {
+          const configFile = resolve(nuxt.options.srcDir, "vue-query.config.ts")
           const file = await loadFile(configFile)
           if (file.exports.pluginHook || file.exports.default) {
             logger.success("Found vue-query.config.ts file")


### PR DESCRIPTION
### 🔗 Linked issue
#77

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The config for the frontend should resolve from `srcDir` instead of `rootDir` from Nuxt v4 onwards, this also aligns the scanned dir with #77.