### PR TITLE
fix: autoImports can now accept arbitrary members of composables

### DIFF
--- a/packages/vue-query-nuxt/src/runtime/utils.ts
+++ b/packages/vue-query-nuxt/src/runtime/utils.ts
@@ -14,7 +14,7 @@ const composables = [
   "useQueryClient"
 ] as const
 
-type VueQueryComposables = typeof composables
+type VueQueryComposables = typeof composables[number][] | false
 export interface ModuleOptions {
   stateKey: string
   autoImports: VueQueryComposables | false


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
#113 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Previously, autoImports required all composables to be passed in its array at once. With this fix, you can select arbitrary members of composables to auto-import.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
